### PR TITLE
feat: pass props to get template method

### DIFF
--- a/src/ce-la-react.ts
+++ b/src/ce-la-react.ts
@@ -87,7 +87,7 @@ type EventListeners<R extends EventNames> = {
 };
 
 type CustomElementConstructor<T> = {
-  getTemplateHTML?: (attrs: Record<string, string>) => string;
+  getTemplateHTML?: (attrs: Record<string, string>, props?: Record<string, any>) => string;
   shadowRootOptions?: {
     mode?: string;
     delegatesFocus?: boolean;
@@ -304,7 +304,7 @@ export function createComponent<I extends HTMLElement, E extends EventNames = {}
         shadowrootmode: mode,
         shadowrootdelegatesfocus: delegatesFocus,
         dangerouslySetInnerHTML: {
-          __html: elementClass.getTemplateHTML(attrs),
+          __html: elementClass.getTemplateHTML(attrs, props),
         },
       });
 

--- a/src/ce-la-react.ts
+++ b/src/ce-la-react.ts
@@ -87,7 +87,7 @@ type EventListeners<R extends EventNames> = {
 };
 
 type CustomElementConstructor<T> = {
-  getTemplateHTML?: (attrs: Record<string, string>, props?: Record<string, any>) => string;
+  getTemplateHTML?: (attrs: Record<string, string>, props?: Record<string, unknown>) => string;
   shadowRootOptions?: {
     mode?: string;
     delegatesFocus?: boolean;


### PR DESCRIPTION
this adds a new props argument to the `getTemplateHTML` method. 

this is needed for example when a property doesn't have an attribute counterpart like with a complex object or other reasons.