### PR TITLE
feat: support setting non-primitive values as props instead of attr

### DIFF
--- a/src/ce-la-react.ts
+++ b/src/ce-la-react.ts
@@ -227,6 +227,13 @@ export function createComponent<I extends HTMLElement, E extends EventNames = {}
         continue;
       }
 
+      const isNonPrimitive = typeof v === 'object' && v !== null;
+      
+      if (isNonPrimitive) {
+        elementProps[k] = v;
+        continue;
+      }
+
       const attrValue = toAttributeValue(v);
 
       if (attrName && attrValue != null) {


### PR DESCRIPTION
This PR updates the **createComponent** logic to ensure that when a web component attribute is a non-primitive (e.g. object, array), it is assigned directly as a property on the custom element.

This change addresses [muxinc/media-chrome#1120](https://github.com/muxinc/media-chrome/issues/1120), where the attribute **rates** in react its expected to be an array and was ignored by the current implementation. 
