### PR TITLE
Fix elementClass.prototype undefined error with corejs polyfill

### DIFF
--- a/src/ce-la-react.ts
+++ b/src/ce-la-react.ts
@@ -218,6 +218,7 @@ export function createComponent<I extends HTMLElement, E extends EventNames = {}
       // a primitive value that should be set as an attribute and will
       // internally be reflected to the accompanying property.
       if (
+        elementClass.prototype &&
         k in elementClass.prototype &&
         !(k in (globalThis.HTMLElement?.prototype ?? {})) &&
         !elementClass.observedAttributes?.some((attr) => attr === attrName)


### PR DESCRIPTION
I'm using `media-elements` which uses `ce-la-react`, and when I use it with `@babel/preset-env` + `corejs`, I get error `Cannot use 'in' operator to search for 'onRateChange' in undefined` from this line. Patching it fixes it.  