### PR TITLE
fix: Added missing key to templateShadowRoot

### DIFF
--- a/src/ce-la-react.ts
+++ b/src/ce-la-react.ts
@@ -201,7 +201,7 @@ export function createComponent<I extends HTMLElement, E extends EventNames = {}
     // Attributes to be passed to getTemplateHTML
     const attrs: Record<string, string> = {};
     // Props to be passed to React.createElement
-    const reactProps: Record<string, unknown> = {};
+    const reactProps: Record<string, unknown> & { children?: React.ReactNode } = {};
     // Props to be set on element with setProperty
     const elementProps: Record<string, unknown> = {};
 
@@ -322,6 +322,7 @@ export function createComponent<I extends HTMLElement, E extends EventNames = {}
         dangerouslySetInnerHTML: {
           __html: elementClass.getTemplateHTML(attrs, props),
         },
+        key: "ce-la-react-ssr-template-shadow-root",
       });
 
       reactProps.children = [templateShadowRoot, reactProps.children];
@@ -341,7 +342,7 @@ export function createComponent<I extends HTMLElement, E extends EventNames = {}
         },
         [ref]
       ),
-    });
+    }, reactProps.children);
   });
 
   ReactComponent.displayName = displayName ?? elementClass.name;


### PR DESCRIPTION
Closes https://github.com/muxinc/ce-la-react/issues/6

The way we create the children array in the SSR case (`typeof window === 'undefined'`) would cause a warning log to appear on NextJS environments. For example: https://github.com/muxinc/next-video/issues/397

```
Check the render method of `i`. See https://react.dev/link/warning-keys for more information.
Each child in a list should have a unique "key" prop.
```

This was happening because `reactProps.children` was being created as an array 
```
reactProps.children = [templateShadowRoot, reactProps.children];
```
but the `templateShadowRoot` element didn't have a key. Tried to go for a unique enough key so it wouldn't be repeated, but feel free to suggest changes.

Unrelated to the bug, I also modified the way we pass the children to the [createElement](https://react.dev/reference/react/createElement) function to follow how it's specified in the docs.

I tested this by publishing the package locally using yalc and linking it to `@mux/mux-video` (and doing the same with this package and `next-video` and it's example). Then when running the example, you shouldn't see the missing key warning.

